### PR TITLE
Added patches from arch

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+bcmwl (6.30.223.271+bdcom-2r2rien1) experimental; urgency=medium
+
+  * Non-maintainer upload
+  * Added patches from arch
+    - See https://aur.archlinux.org/packages/broadcom-wl/.
+    - 0019_linux-4.07.patch.
+    - 0019_linux-4.08.patch.
+    - 0019_linux-4.11.patch.
+    - 0019_linux-4.12.patch.
+    - 0019_linux-4.15.patch.
+
+ -- r2rien <r2rien@gmail.com>  Mon, 05 Mar 2018 02:27:41 +0100
+
 bcmwl (6.30.223.271+bdcom-1longsleep0) wily; urgency=medium
 
   * New upstream release

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ bcmwl (6.30.223.271+bdcom-2r2rien1) experimental; urgency=medium
 
   * Non-maintainer upload
   * Added patches from arch
-    - See https://aur.archlinux.org/packages/broadcom-wl/.
+    - See https://www.archlinux.org/packages/community/x86_64/broadcom-wl-dkms/.
     - 0019_linux-4.07.patch.
     - 0019_linux-4.08.patch.
     - 0019_linux-4.11.patch.

--- a/debian/patches/0019_linux-4.07.patch
+++ b/debian/patches/0019_linux-4.07.patch
@@ -1,0 +1,109 @@
+Since Linux 4.7, the enum ieee80211_band is no longer used
+
+This shall cause no problem's since both enums ieee80211_band
+and nl80211_band were added in the same commit:
+https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=13ae75b103e07304a34ab40c9136e9f53e06475c
+
+This patch refactors the references of IEEE80211_BAND_* to NL80211_BAND_*
+
+Reference:
+https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit?id=57fbcce37be7c1d2622b56587c10ade00e96afa3
+
+--- a/src/wl/sys/wl_cfg80211_hybrid.c	2016-06-13 11:57:36.159340297 -0500
++++ b/src/wl/sys/wl_cfg80211_hybrid.c	2016-06-13 11:58:18.442323435 -0500
+@@ -236,7 +236,7 @@
+ #endif				
+ 
+ #define CHAN2G(_channel, _freq, _flags) {			\
+-	.band			= IEEE80211_BAND_2GHZ,		\
++	.band			= NL80211_BAND_2GHZ,		\
+ 	.center_freq		= (_freq),			\
+ 	.hw_value		= (_channel),			\
+ 	.flags			= (_flags),			\
+@@ -245,7 +245,7 @@
+ }
+ 
+ #define CHAN5G(_channel, _flags) {				\
+-	.band			= IEEE80211_BAND_5GHZ,		\
++	.band			= NL80211_BAND_5GHZ,		\
+ 	.center_freq		= 5000 + (5 * (_channel)),	\
+ 	.hw_value		= (_channel),			\
+ 	.flags			= (_flags),			\
+@@ -379,7 +379,7 @@
+ };
+ 
+ static struct ieee80211_supported_band __wl_band_2ghz = {
+-	.band = IEEE80211_BAND_2GHZ,
++	.band = NL80211_BAND_2GHZ,
+ 	.channels = __wl_2ghz_channels,
+ 	.n_channels = ARRAY_SIZE(__wl_2ghz_channels),
+ 	.bitrates = wl_g_rates,
+@@ -387,7 +387,7 @@
+ };
+ 
+ static struct ieee80211_supported_band __wl_band_5ghz_a = {
+-	.band = IEEE80211_BAND_5GHZ,
++	.band = NL80211_BAND_5GHZ,
+ 	.channels = __wl_5ghz_a_channels,
+ 	.n_channels = ARRAY_SIZE(__wl_5ghz_a_channels),
+ 	.bitrates = wl_a_rates,
+@@ -395,7 +395,7 @@
+ };
+ 
+ static struct ieee80211_supported_band __wl_band_5ghz_n = {
+-	.band = IEEE80211_BAND_5GHZ,
++	.band = NL80211_BAND_5GHZ,
+ 	.channels = __wl_5ghz_n_channels,
+ 	.n_channels = ARRAY_SIZE(__wl_5ghz_n_channels),
+ 	.bitrates = wl_a_rates,
+@@ -1876,8 +1876,8 @@
+ 	wdev->wiphy->max_num_pmkids = WL_NUM_PMKIDS_MAX;
+ #endif
+ 	wdev->wiphy->interface_modes = BIT(NL80211_IFTYPE_STATION) | BIT(NL80211_IFTYPE_ADHOC);
+-	wdev->wiphy->bands[IEEE80211_BAND_2GHZ] = &__wl_band_2ghz;
+-	wdev->wiphy->bands[IEEE80211_BAND_5GHZ] = &__wl_band_5ghz_a; 
++	wdev->wiphy->bands[NL80211_BAND_2GHZ] = &__wl_band_2ghz;
++	wdev->wiphy->bands[NL80211_BAND_5GHZ] = &__wl_band_5ghz_a; 
+ 	wdev->wiphy->signal_type = CFG80211_SIGNAL_TYPE_MBM;
+ 	wdev->wiphy->cipher_suites = __wl_cipher_suites;
+ 	wdev->wiphy->n_cipher_suites = ARRAY_SIZE(__wl_cipher_suites);
+@@ -2000,7 +2000,7 @@
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39)
+ 	freq = ieee80211_channel_to_frequency(notif_bss_info->channel,
+ 		(notif_bss_info->channel <= CH_MAX_2G_CHANNEL) ?
+-		IEEE80211_BAND_2GHZ : IEEE80211_BAND_5GHZ);
++		NL80211_BAND_2GHZ : NL80211_BAND_5GHZ);
+ #else
+ 	freq = ieee80211_channel_to_frequency(notif_bss_info->channel);
+ #endif
+@@ -2116,7 +2116,7 @@
+ 				return err;
+ 			}
+ 			chan = wf_chspec_ctlchan(chanspec);
+-			band = (chan <= CH_MAX_2G_CHANNEL) ? IEEE80211_BAND_2GHZ : IEEE80211_BAND_5GHZ;
++			band = (chan <= CH_MAX_2G_CHANNEL) ? NL80211_BAND_2GHZ : NL80211_BAND_5GHZ;
+ 			freq = ieee80211_channel_to_frequency(chan, band);
+ 			channel = ieee80211_get_channel(wiphy, freq);
+ 			cfg80211_ibss_joined(ndev, (u8 *)&wl->bssid, channel, GFP_KERNEL);
+@@ -2250,10 +2250,10 @@
+ 		join_params->params.chanspec_list[0] =
+ 		    ieee80211_frequency_to_channel(chan->center_freq);
+ 
+-		if (chan->band == IEEE80211_BAND_2GHZ) {
++		if (chan->band == NL80211_BAND_2GHZ) {
+ 			chanspec |= WL_CHANSPEC_BAND_2G;
+ 		}
+-		else if (chan->band == IEEE80211_BAND_5GHZ) {
++		else if (chan->band == NL80211_BAND_5GHZ) {
+ 			chanspec |= WL_CHANSPEC_BAND_5G;
+ 		}
+ 		else {
+@@ -2885,7 +2885,7 @@
+ 
+ 	if (phy == 'n' || phy == 'a' || phy == 'v') {
+ 		wiphy = wl_to_wiphy(wl);
+-		wiphy->bands[IEEE80211_BAND_5GHZ] = &__wl_band_5ghz_n;
++		wiphy->bands[NL80211_BAND_5GHZ] = &__wl_band_5ghz_n;
+ 	}
+ 
+ 	return err;

--- a/debian/patches/0019_linux-4.08.patch
+++ b/debian/patches/0019_linux-4.08.patch
@@ -1,0 +1,52 @@
+Reference: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=839629
+
+--- a/src/wl/sys/wl_cfg80211_hybrid.c	2016-10-03 10:53:55.588036464 +0200
++++ b/src/wl/sys/wl_cfg80211_hybrid.c	2016-10-03 10:54:11.911695944 +0200
+@@ -2386,8 +2386,15 @@
+ 	s32 err = 0;
+ 
+ 	if (wl->scan_request) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
++		struct cfg80211_scan_info info = {
++			.aborted = true
++		};
+ 		WL_DBG(("%s: Aborting scan\n", __FUNCTION__));
+-		cfg80211_scan_done(wl->scan_request, true);     
++		cfg80211_scan_done(wl->scan_request, &info);
++#else
++		cfg80211_scan_done(wl->scan_request, true);
++#endif
+ 		wl->scan_request = NULL;
+ 	}
+ 
+@@ -2488,7 +2495,14 @@
+ 
+ scan_done_out:
+ 	if (wl->scan_request) {
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
++		struct cfg80211_scan_info info = {
++			.aborted = false
++		};
++		cfg80211_scan_done(wl->scan_request, &info);
++#else
+ 		cfg80211_scan_done(wl->scan_request, false);
++#endif
+ 		wl->scan_request = NULL;
+ 	}
+ 	rtnl_unlock();
+@@ -2913,7 +2927,14 @@
+ 	s32 err = 0;
+ 
+ 	if (wl->scan_request) {
+-		cfg80211_scan_done(wl->scan_request, true);	
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
++		struct cfg80211_scan_info info = {
++			.aborted = true
++		};
++		cfg80211_scan_done(wl->scan_request, &info);
++#else
++		cfg80211_scan_done(wl->scan_request, true);
++#endif
+ 		wl->scan_request = NULL;
+ 	}
+ 

--- a/debian/patches/0019_linux-4.11.patch
+++ b/debian/patches/0019_linux-4.11.patch
@@ -1,0 +1,52 @@
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index a9671e2..da36405 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -30,6 +30,9 @@
+ #include <linux/kthread.h>
+ #include <linux/netdevice.h>
+ #include <linux/ieee80211.h>
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++#include <linux/sched/signal.h>
++#endif
+ #include <net/cfg80211.h>
+ #include <linux/nl80211.h>
+ #include <net/rtnetlink.h>
+diff --git a/src/wl/sys/wl_linux.c b/src/wl/sys/wl_linux.c
+index 0d05100..0addd56 100644
+--- a/src/wl/sys/wl_linux.c
++++ b/src/wl/sys/wl_linux.c
+@@ -117,6 +117,9 @@ int wl_found = 0;
+ 
+ typedef struct priv_link {
+ 	wl_if_t *wlif;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++	unsigned long last_rx;
++#endif
+ } priv_link_t;
+ 
+ #define WL_DEV_IF(dev)          ((wl_if_t*)((priv_link_t*)DEV_PRIV(dev))->wlif)
+@@ -2449,6 +2452,9 @@ wl_monitor(wl_info_t *wl, wl_rxsts_t *rxsts, void *p)
+ {
+ 	struct sk_buff *oskb = (struct sk_buff *)p;
+ 	struct sk_buff *skb;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++	priv_link_t *priv_link;
++#endif
+ 	uchar *pdata;
+ 	uint len;
+ 
+@@ -2915,7 +2921,13 @@ wl_monitor(wl_info_t *wl, wl_rxsts_t *rxsts, void *p)
+ 	if (skb == NULL) return;
+ 
+ 	skb->dev = wl->monitor_dev;
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 11, 0)
++	priv_link = MALLOC(wl->osh, sizeof(priv_link_t));
++	priv_link = netdev_priv(skb->dev);
++	priv_link->last_rx = jiffies;
++#else
+ 	skb->dev->last_rx = jiffies;
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 22)
+ 	skb_reset_mac_header(skb);
+ #else

--- a/debian/patches/0019_linux-4.12.patch
+++ b/debian/patches/0019_linux-4.12.patch
@@ -1,0 +1,68 @@
+diff --git a/src/wl/sys/wl_cfg80211_hybrid.c b/src/wl/sys/wl_cfg80211_hybrid.c
+index da36405..d3741eb 100644
+--- a/src/wl/sys/wl_cfg80211_hybrid.c
++++ b/src/wl/sys/wl_cfg80211_hybrid.c
+@@ -53,7 +53,11 @@ u32 wl_dbg_level = WL_DBG_ERR;
+ #endif
+ 
+ static s32 wl_cfg80211_change_iface(struct wiphy *wiphy, struct net_device *ndev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++           enum nl80211_iftype type, struct vif_params *params);
++#else
+            enum nl80211_iftype type, u32 *flags, struct vif_params *params);
++#endif
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 6, 0)
+ static s32
+ wl_cfg80211_scan(struct wiphy *wiphy,
+@@ -466,7 +470,11 @@ wl_dev_ioctl(struct net_device *dev, u32 cmd, void *arg, u32 len)
+ 
+ static s32
+ wl_cfg80211_change_iface(struct wiphy *wiphy, struct net_device *ndev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++                         enum nl80211_iftype type,
++#else
+                          enum nl80211_iftype type, u32 *flags,
++#endif
+    struct vif_params *params)
+ {
+ 	struct wl_cfg80211_priv *wl = wiphy_to_wl(wiphy);
+@@ -2361,6 +2369,20 @@ wl_bss_roaming_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,
+                     const wl_event_msg_t *e, void *data)
+ {
+ 	struct wl_cfg80211_connect_info *conn_info = wl_to_conn(wl);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++	struct cfg80211_bss *bss;
++	struct wlc_ssid *ssid;
++	ssid = &wl->profile->ssid;
++	bss = cfg80211_get_bss(wl_to_wiphy(wl), NULL, (s8 *)&wl->bssid,
++	ssid->SSID, ssid->SSID_len, WLAN_CAPABILITY_ESS, WLAN_CAPABILITY_ESS);
++	struct cfg80211_roam_info roam_info = {
++		.bss = bss,
++		.req_ie = conn_info->req_ie,
++		.req_ie_len = conn_info->req_ie_len,
++		.resp_ie = conn_info->resp_ie,
++		.resp_ie_len = conn_info->resp_ie_len,
++	};
++#endif
+ 	s32 err = 0;
+ 
+ 	wl_get_assoc_ies(wl);
+@@ -2368,12 +2390,17 @@ wl_bss_roaming_done(struct wl_cfg80211_priv *wl, struct net_device *ndev,
+ 	memcpy(&wl->bssid, &e->addr, ETHER_ADDR_LEN);
+ 	wl_update_bss_info(wl);
+ 	cfg80211_roamed(ndev,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
++			&roam_info,
++#else
+ #if LINUX_VERSION_CODE > KERNEL_VERSION(2, 6, 39)
+ 			&wl->conf->channel,	 
+ #endif
+ 			(u8 *)&wl->bssid,
+ 			conn_info->req_ie, conn_info->req_ie_len,
+-			conn_info->resp_ie, conn_info->resp_ie_len, GFP_KERNEL);
++			conn_info->resp_ie, conn_info->resp_ie_len,
++#endif
++			GFP_KERNEL);
+ 	WL_DBG(("Report roaming result\n"));
+ 
+ 	set_bit(WL_STATUS_CONNECTED, &wl->status);

--- a/debian/patches/0019_linux-4.15.patch
+++ b/debian/patches/0019_linux-4.15.patch
@@ -1,0 +1,46 @@
+--- a/src/wl/sys/wl_linux.c	2017-07-17 00:11:24.000000000 +0100
++++ b/src/wl/sys/wl_linux.c	2018-01-27 09:49:47.057799596 +0000
+@@ -93,7 +93,11 @@
+ 
+ #include <wlc_wowl.h>
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++static void wl_timer(struct timer_list *tl);
++#else
+ static void wl_timer(ulong data);
++#endif
+ static void _wl_timer(wl_timer_t *t);
+ static struct net_device *wl_alloc_linux_if(wl_if_t *wlif);
+ 
+@@ -2297,10 +2301,17 @@
+ 	atomic_dec(&t->wl->callbacks);
+ }
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++static void
++wl_timer(struct timer_list *tl)
++{
++	wl_timer_t *t = (wl_timer_t *)tl;
++#else
+ static void
+ wl_timer(ulong data)
+ {
+ 	wl_timer_t *t = (wl_timer_t *)data;
++#endif
+ 
+ 	if (!WL_ALL_PASSIVE_ENAB(t->wl))
+ 		_wl_timer(t);
+@@ -2352,9 +2363,13 @@
+ 
+ 	bzero(t, sizeof(wl_timer_t));
+ 
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
++	timer_setup(&t->timer, wl_timer, 0);
++#else
+ 	init_timer(&t->timer);
+ 	t->timer.data = (ulong) t;
+ 	t->timer.function = wl_timer;
++#endif
+ 	t->wl = wl;
+ 	t->fn = fn;
+ 	t->arg = arg;


### PR DESCRIPTION
Hi, I've been using since long on my dell xps13
and its Broadcom Corporation BCM4352 802.11ac Wireless Network Adapter (rev 03)
a successfully builded version with this added patches from arch linux
thus with kernel up to 4.19 for now
sorry for not proposing this version sooner
cheers